### PR TITLE
Generalize the mosiac file name that chgres_cube can read in.

### DIFF
--- a/sorc/chgres_cube.fd/program_setup.f90
+++ b/sorc/chgres_cube.fd/program_setup.f90
@@ -254,7 +254,7 @@
 !-------------------------------------------------------------------------
 
  is = index(mosaic_file_target_grid, "/", .true.)
- ie = index(mosaic_file_target_grid, "_mosaic")
+ ie = index(mosaic_file_target_grid, "mosaic") - 1
 
  if (is == 0 .or. ie == 0) then
    call error_handler("CANT DETERMINE CRES FROM MOSAIC FILE.", 1)


### PR DESCRIPTION
This PR allows chgres_cube to read in a mosaic file with a name that has any separator character (not just an underscore) between the starting $CRES and the string "mosaic" that follows $CRES.  For example, this will allow the mosaic file to be named C768.mosaic.halo4.nc instead of C768_mosaic.halo4.nc (note the "." instead of the "_" after "C768").

This is to allow the regional_workflow to use fixed file names for the grid and orography files that have the same naming convention as the fixed surface climo files that the sfc_climo_gen code generates.  That convention is to use a "." between the $CRES and the string "mosaic" instead of an underscore.

This was tested in the regional_workflow and works both for the case of an "_" and a "." as the separator character in the mosaic file name.